### PR TITLE
Add simple payment reference storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-error.log*
 next-env.d.ts
 
 .env
+dist/

--- a/app/api/confirm-payment/route.ts
+++ b/app/api/confirm-payment/route.ts
@@ -1,6 +1,7 @@
 import { MiniAppPaymentSuccessPayload } from "@worldcoin/minikit-js";
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
+import { getReferenceFromDB } from "@/lib/paymentStore";
 
 interface IRequestPayload {
   payload: MiniAppPaymentSuccessPayload;
@@ -9,11 +10,11 @@ interface IRequestPayload {
 export async function POST(req: NextRequest) {
   const { payload } = (await req.json()) as IRequestPayload;
 
-  // IMPORTANT: Here we should fetch the reference you created in /initiate-payment to ensure the transaction we are verifying is the same one we initiated
-  //   const reference = getReferenceFromDB();
+  // Fetch the reference saved when initiating the payment
+  const dbReference = await getReferenceFromDB();
   const cookieStore = cookies();
 
-  const reference = cookieStore.get("payment-nonce")?.value;
+  const reference = dbReference ?? cookieStore.get("payment-nonce")?.value;
 
   console.log(reference);
 

--- a/app/api/initiate-payment/route.ts
+++ b/app/api/initiate-payment/route.ts
@@ -1,10 +1,12 @@
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
+import { savePaymentReference } from "@/lib/paymentStore";
 
 export async function POST(req: NextRequest) {
   const uuid = crypto.randomUUID().replace(/-/g, "");
 
-  // TODO: Store the ID field in your database so you can verify the payment later
+  // Save the generated reference so we can verify the payment later
+  await savePaymentReference(uuid);
   cookies().set({
     name: "payment-nonce",
     value: uuid,

--- a/lib/paymentStore.ts
+++ b/lib/paymentStore.ts
@@ -1,0 +1,10 @@
+let lastReference: string | null = null;
+
+export async function savePaymentReference(id: string): Promise<void> {
+  lastReference = id;
+}
+
+export async function getReferenceFromDB(): Promise<string | null> {
+  return lastReference;
+}
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "rm -rf dist && tsc -p tsconfig.test.json && node --test test/paymentStore.test.js"
   },
   "dependencies": {
     "@worldcoin/mini-apps-ui-kit-react": "^1.2.3",

--- a/test/paymentStore.test.js
+++ b/test/paymentStore.test.js
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { savePaymentReference, getReferenceFromDB } from '../dist/paymentStore.js';
+
+test('saves and retrieves payment reference', async () => {
+  await savePaymentReference('123');
+  const ref = await getReferenceFromDB();
+  assert.equal(ref, '123');
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmit": false,
+    "outDir": "dist"
+  },
+  "include": ["lib/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- store payment references in an in-memory module
- save generated reference when initiating a payment
- fetch reference from storage in confirm-payment route
- add Node test and tsconfig for compiling libs
- ignore dist folder during development

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683aca9654408322bddd88b4f75412e0