### PR TITLE
Add birth info page

### DIFF
--- a/app/birth/page.tsx
+++ b/app/birth/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+import { useState } from "react";
+import { BackButton } from "@/components/BackButton";
+
+export default function BirthPage() {
+  const [day, setDay] = useState("");
+  const [month, setMonth] = useState("");
+  const [year, setYear] = useState("");
+  const [place, setPlace] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const data = { day, month, year, place };
+    if (process.env.NODE_ENV !== "production") {
+      console.log("Birth info submitted", data);
+    }
+  };
+
+  return (
+    <main className="flex min-h-screen flex-col p-4">
+      <BackButton />
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4 max-w-sm mx-auto w-full">
+        <h1 className="text-xl font-semibold text-center">Enter your birth information</h1>
+        <div className="flex gap-2">
+          <input
+            type="number"
+            placeholder="Day"
+            value={day}
+            onChange={(e) => setDay(e.target.value)}
+            className="border p-2 rounded flex-1"
+            min="1"
+            max="31"
+            required
+          />
+          <input
+            type="number"
+            placeholder="Month"
+            value={month}
+            onChange={(e) => setMonth(e.target.value)}
+            className="border p-2 rounded flex-1"
+            min="1"
+            max="12"
+            required
+          />
+          <input
+            type="number"
+            placeholder="Year"
+            value={year}
+            onChange={(e) => setYear(e.target.value)}
+            className="border p-2 rounded flex-1"
+            min="1900"
+            max="2100"
+            required
+          />
+        </div>
+        <input
+          type="text"
+          placeholder="Birth place"
+          list="birth-places"
+          value={place}
+          onChange={(e) => setPlace(e.target.value)}
+          className="border p-2 rounded w-full"
+          required
+        />
+        <datalist id="birth-places">
+          <option value="New York, USA" />
+          <option value="London, UK" />
+          <option value="Tokyo, Japan" />
+          <option value="Sydney, Australia" />
+          <option value="Paris, France" />
+        </datalist>
+        <button type="submit" className="bg-blue-500 text-white p-2 rounded">Submit</button>
+      </form>
+    </main>
+  );
+}

--- a/app/start/page.tsx
+++ b/app/start/page.tsx
@@ -14,7 +14,7 @@ export default function StartPage() {
     const result = await handlePay();
     setLoading(false);
     if (result) {
-      router.push("/message");
+      router.push("/birth");
     } else {
       alert("Payment failed or was cancelled.");
     }


### PR DESCRIPTION
## Summary
- add a standalone `/birth` page to collect birthday and birthplace
- redirect successful payments on `/start` to the new page

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_683ad58984a883228a2da86b364324ae