### PR TITLE
Use mp4 backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To use the application, you'll need to:
    - Use the same action name in `components/VerifyButton.tsx`
 
 ### Background animation
-Place your optimized SVG file at `public/background.svg`. A placeholder file is included in this repository; replace it with your own animation to display it as the home page background.
+Place your optimized MP4 file at `public/background.mp4`. A placeholder file is included in this repository; replace it with your own video to display it as the home page background.
 
 View docs: [Docs](https://docs.world.org/)
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,11 +3,15 @@ import { VerifyButton } from "@/components/VerifyButton";
 export default function Home() {
   return (
     <main className="relative min-h-screen overflow-hidden">
-      <img
-        src="/background.svg"
-        alt="Background animation"
+      <video
+        autoPlay
+        muted
+        loop
+        playsInline
         className="absolute top-0 left-0 w-full h-full object-cover"
-      />
+      >
+        <source src="/background.mp4" type="video/mp4" />
+      </video>
       <div className="relative z-10 flex flex-col min-h-screen">
         <div className="flex-1" />
         <footer className="p-4 flex justify-center">

--- a/app/universe/page.tsx
+++ b/app/universe/page.tsx
@@ -4,11 +4,15 @@ import { Button } from "@worldcoin/mini-apps-ui-kit-react";
 export default function UniversePage() {
   return (
     <main className="relative min-h-screen overflow-hidden">
-      <img
-        src="/universe.svg"
-        alt="Universe animation"
+      <video
+        autoPlay
+        muted
+        loop
+        playsInline
         className="absolute top-0 left-0 w-full h-full object-cover"
-      />
+      >
+        <source src="/universe.mp4" type="video/mp4" />
+      </video>
       <div className="relative z-10 flex flex-col min-h-screen">
         <div className="flex-1" />
         <footer className="p-4 flex justify-center">


### PR DESCRIPTION
## Summary
- revert SVG backgrounds and play mp4 videos instead
- update README to mention mp4 background
- keep original class names for background videos

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_683ae0df6b648322940f4457681d61e5