### PR TITLE
Adjust page flow to add wait page

### DIFF
--- a/app/message/page.tsx
+++ b/app/message/page.tsx
@@ -1,8 +1,19 @@
+"use client";
 import Link from "next/link";
 import { Button } from "@worldcoin/mini-apps-ui-kit-react";
 import { BackButton } from "@/components/BackButton";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 export default function MessagePage() {
+  const router = useRouter();
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      router.push("/wait");
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, [router]);
+
   return (
     <main className="flex min-h-screen flex-col gap-6 p-4">
       <BackButton />

--- a/app/universe/page.tsx
+++ b/app/universe/page.tsx
@@ -20,7 +20,7 @@ export default function UniversePage() {
         </div>
         <div className="flex-1" />
         <footer className="p-4 flex justify-center">
-          <Link href="/start">
+          <Link href="/birth">
             <Button variant="primary" size="lg">Start</Button>
           </Link>
         </footer>

--- a/app/wait/page.tsx
+++ b/app/wait/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export default function WaitPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-4">
+      <div className="animate-spin h-16 w-16 rounded-full border-4 border-blue-500 border-t-transparent" />
+      <p className="text-lg text-center">Please wait while we process your request...</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- redirect from Universe page to the birth flow
- redirect to `/message` after submitting the birth form
- auto redirect from the message page to `/wait`
- add new wait page with simple spinner

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683add963fe88322be49914357b6b456