### PR TITLE
Add delay before redirect on universe start

### DIFF
--- a/app/universe/page.tsx
+++ b/app/universe/page.tsx
@@ -1,9 +1,19 @@
-import Link from "next/link";
+"use client";
+import { useRouter } from "next/navigation";
 import { Button } from "@worldcoin/mini-apps-ui-kit-react";
 import { BackButton } from "@/components/BackButton";
 import { playBackgroundVideo } from "@/lib/playVideo";
 
 export default function UniversePage() {
+  const router = useRouter();
+
+  const handleStart = () => {
+    playBackgroundVideo();
+    setTimeout(() => {
+      router.push("/birth");
+    }, 4000);
+  };
+
   return (
     <main className="relative min-h-screen overflow-hidden">
       <video
@@ -22,9 +32,7 @@ export default function UniversePage() {
         </div>
         <div className="flex-1" />
         <footer className="p-4 flex justify-center">
-          <Link href="/birth" onClick={playBackgroundVideo}>
-            <Button variant="primary" size="lg">Start</Button>
-          </Link>
+          <Button onClick={handleStart} variant="primary" size="lg">Start</Button>
         </footer>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- convert `app/universe/page.tsx` to a client component
- start playing the background video and wait 4 seconds before navigating to `/birth`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_683aec6095148322967d898947b129e5