### PR TITLE
Add birth page background image and simplify wait page

### DIFF
--- a/app/birth/page.tsx
+++ b/app/birth/page.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { BackButton } from "@/components/BackButton";
 import { useRouter } from "next/navigation";
 import { Button } from "@worldcoin/mini-apps-ui-kit-react";
+import Image from "next/image";
 
 export default function BirthPage() {
   const router = useRouter();
@@ -21,10 +22,18 @@ export default function BirthPage() {
   };
 
   return (
-    <main className="flex min-h-screen flex-col p-4">
-      <BackButton />
-      <form onSubmit={handleSubmit} className="flex flex-col gap-4 max-w-sm mx-auto w-full">
-        <h1 className="text-xl font-semibold text-center">Enter your birth information</h1>
+    <main className="relative min-h-screen overflow-hidden">
+      <Image
+        src="/birth.svg"
+        alt="Birth background"
+        fill
+        priority
+        className="object-cover"
+      />
+      <div className="relative z-10 flex min-h-screen flex-col p-4">
+        <BackButton />
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4 max-w-sm mx-auto w-full">
+          <h1 className="text-xl font-semibold text-center">Enter your birth information</h1>
         <div className="flex gap-2">
           <input
             type="number"
@@ -77,6 +86,7 @@ export default function BirthPage() {
           Submit
         </Button>
       </form>
+      </div>
     </main>
   );
 }

--- a/app/wait/page.tsx
+++ b/app/wait/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import { BackButton } from "@/components/BackButton";
+
 export default function WaitPage() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-4">
-      <div className="animate-spin h-16 w-16 rounded-full border-4 border-blue-500 border-t-transparent" />
-      <p className="text-lg text-center">Please wait while we process your request...</p>
+    <main className="flex min-h-screen flex-col p-4">
+      <BackButton />
     </main>
   );
 }

--- a/public/birth.svg
+++ b/public/birth.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600" viewBox="0 0 800 600">
+  <rect width="800" height="600" fill="#cccccc"/>
+  <text x="400" y="300" text-anchor="middle" dominant-baseline="middle" font-size="48" fill="#555555">
+    Birth Background Placeholder
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- add placeholder image for birth page background
- show background image on birth page
- remove spinner from wait page

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_683b08c5e44483228c66e16c06dcea46