### PR TITLE
Center start button on Universe page

### DIFF
--- a/app/universe/page.tsx
+++ b/app/universe/page.tsx
@@ -3,12 +3,15 @@ import { useRouter } from "next/navigation";
 import { Button } from "@worldcoin/mini-apps-ui-kit-react";
 import { BackButton } from "@/components/BackButton";
 import { playBackgroundVideo } from "@/lib/playVideo";
+import { useState } from "react";
 
 export default function UniversePage() {
   const router = useRouter();
+  const [showStart, setShowStart] = useState(true);
 
   const handleStart = () => {
     playBackgroundVideo();
+    setShowStart(false);
     setTimeout(() => {
       router.push("/birth");
     }, 4000);
@@ -17,7 +20,6 @@ export default function UniversePage() {
   return (
     <main className="relative min-h-screen overflow-hidden">
       <video
-        autoPlay
         muted
         loop
         playsInline
@@ -31,9 +33,13 @@ export default function UniversePage() {
           <BackButton className="text-white border-white" />
         </div>
         <div className="flex-1" />
-        <footer className="p-4 flex justify-center">
-          <Button onClick={handleStart} variant="primary" size="lg">Start</Button>
-        </footer>
+        {showStart && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <Button onClick={handleStart} variant="primary" size="lg">
+              Start
+            </Button>
+          </div>
+        )}
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- center the start button over the video on `/universe`
- hide the start button once pressed and trigger video playback

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683b1ce4a0188322a4523c3401d7eec2