### PR TITLE
Persist payment nonce via sqlite

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,6 @@
 import NextAuth, { NextAuthOptions } from "next-auth";
 
-const authOptions: NextAuthOptions = {
+export const authOptions: NextAuthOptions = {
   secret: process.env.NEXTAUTH_SECRET,
 
   providers: [

--- a/app/api/initiate-payment/route.ts
+++ b/app/api/initiate-payment/route.ts
@@ -1,14 +1,22 @@
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../auth/[...nextauth]/route";
+import { insertPayment } from "@/lib/db";
 
 export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const userId = session?.user?.id ?? null;
   const uuid = crypto.randomUUID().replace(/-/g, "");
 
-  // TODO: Store the ID field in your database so you can verify the payment later
+  insertPayment(userId, uuid);
+
+  // Store nonce in a short-lived cookie for legacy support
   cookies().set({
     name: "payment-nonce",
     value: uuid,
     httpOnly: true,
+    maxAge: 60 * 5,
   });
 
   if (process.env.NODE_ENV !== "production") {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,26 @@
+import Database from "better-sqlite3";
+
+const db = new Database(process.env.DB_PATH || "payments.sqlite");
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS payments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    userId TEXT,
+    reference TEXT UNIQUE
+  );
+`);
+
+export function insertPayment(userId: string | null, reference: string) {
+  const stmt = db.prepare(
+    "INSERT INTO payments (userId, reference) VALUES (?, ?)"
+  );
+  stmt.run(userId, reference);
+}
+
+export function getLatestPaymentReference(userId: string | null): string | null {
+  const stmt = db.prepare(
+    "SELECT reference FROM payments WHERE userId = ? ORDER BY id DESC LIMIT 1"
+  );
+  const row = stmt.get(userId);
+  return row ? (row.reference as string) : null;
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "eruda": "^3.2.3",
     "next": "14.2.6",
     "next-auth": "^4.24.7",
+    "better-sqlite3": "^9.0.0",
     "react": "^18",
     "react-dom": "^18"
   },


### PR DESCRIPTION
## Summary
- persist payment nonces in a tiny SQLite DB
- use the session's user id when storing and retrieving nonces
- export `authOptions` for reuse in API routes
- keep a short-lived cookie for compatibility
- add better-sqlite3 dependency

## Testing
- `npm run lint`
- `npm run build` *(fails: Module not found: Can't resolve 'better-sqlite3')*

------
https://chatgpt.com/codex/tasks/task_e_683b243736608322840ab5dfa5d80172