### PR TITLE
Add card selection and ritual collection pages

### DIFF
--- a/app/card-selection/page.tsx
+++ b/app/card-selection/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { BackButton } from "@/components/BackButton";
+
+export default function CardSelectionPage() {
+  const router = useRouter();
+  const [selected, setSelected] = useState<number | null>(null);
+
+  const handleSelect = (card: number) => {
+    setSelected(card);
+    router.push(`/ritual-collection?card=${card}`);
+  };
+
+  const cards = [1, 2, 3];
+
+  return (
+    <main className="relative min-h-screen overflow-hidden">
+      <Image
+        src="/card-selection-bg.svg"
+        alt="blue background"
+        fill
+        priority
+        className="object-cover"
+      />
+      <div className="relative z-10 flex min-h-screen flex-col p-4">
+        <BackButton />
+        <div className="flex flex-1 items-center justify-center gap-4">
+          {cards.map((card) => (
+            <button
+              key={card}
+              onClick={() => handleSelect(card)}
+              className={`border-2 rounded overflow-hidden ${selected === card ? "border-amber" : "border-transparent"}`}
+            >
+              <Image
+                src={`/card-${card}.svg`}
+                alt={`card ${card}`}
+                width={100}
+                height={150}
+                className="object-cover"
+              />
+            </button>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/ritual-collection/page.tsx
+++ b/app/ritual-collection/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { useSearchParams } from "next/navigation";
+import { BackButton } from "@/components/BackButton";
+
+export default function RitualCollectionPage() {
+  const searchParams = useSearchParams();
+  const card = searchParams.get("card");
+
+  return (
+    <main className="flex min-h-screen flex-col p-4 gap-6">
+      <BackButton />
+      <div className="flex-1 flex flex-col items-center justify-center gap-6">
+        <h1 className="text-2xl font-semibold">Ritual Collection</h1>
+        {card && <p>You selected card {card}</p>}
+      </div>
+    </main>
+  );
+}

--- a/public/card-1.svg
+++ b/public/card-1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="300" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#e2e8f0" stroke="#000" />
+  <text x="100" y="150" text-anchor="middle" dominant-baseline="middle" font-size="48" fill="#000">1</text>
+</svg>

--- a/public/card-2.svg
+++ b/public/card-2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="300" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#e2e8f0" stroke="#000" />
+  <text x="100" y="150" text-anchor="middle" dominant-baseline="middle" font-size="48" fill="#000">2</text>
+</svg>

--- a/public/card-3.svg
+++ b/public/card-3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="300" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#e2e8f0" stroke="#000" />
+  <text x="100" y="150" text-anchor="middle" dominant-baseline="middle" font-size="48" fill="#000">3</text>
+</svg>

--- a/public/card-selection-bg.svg
+++ b/public/card-selection-bg.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600" viewBox="0 0 800 600">
+  <rect width="800" height="600" fill="#1e3a8a"/>
+  <text x="400" y="300" text-anchor="middle" dominant-baseline="middle" font-size="48" fill="white">Card Selection Background</text>
+</svg>


### PR DESCRIPTION
## Summary
- add new page for card selection with blue background and three selectable cards
- keep chosen card in URL and display on ritual collection page
- include placeholder assets for the background and cards

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_683b49cd7290832296dd461a29be0c6c