### PR TITLE
Add wallet login page using Wallet Auth

### DIFF
--- a/app/api/complete-siwe/route.ts
+++ b/app/api/complete-siwe/route.ts
@@ -1,0 +1,32 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { MiniAppWalletAuthSuccessPayload, verifySiweMessage } from "@worldcoin/minikit-js";
+
+interface IRequestPayload {
+  payload: MiniAppWalletAuthSuccessPayload;
+  nonce: string;
+}
+
+export async function POST(req: NextRequest) {
+  const { payload, nonce } = (await req.json()) as IRequestPayload;
+  if (nonce != cookies().get("siwe")?.value) {
+    return NextResponse.json({
+      status: "error",
+      isValid: false,
+      message: "Invalid nonce",
+    });
+  }
+  try {
+    const validMessage = await verifySiweMessage(payload, nonce);
+    return NextResponse.json({
+      status: "success",
+      isValid: validMessage.isValid,
+    });
+  } catch (error: any) {
+    return NextResponse.json({
+      status: "error",
+      isValid: false,
+      message: error.message,
+    });
+  }
+}

--- a/app/api/nonce/route.ts
+++ b/app/api/nonce/route.ts
@@ -1,0 +1,8 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+export function GET(req: NextRequest) {
+  const nonce = crypto.randomUUID().replace(/-/g, "");
+  cookies().set("siwe", nonce, { secure: true });
+  return NextResponse.json({ nonce });
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,24 @@
+import { LoginButton } from "@/components/LoginButton";
+
+export default function Login() {
+  return (
+    <main className="relative min-h-screen overflow-hidden">
+      <video
+        autoPlay
+        muted
+        loop
+        playsInline
+        id="background-video"
+        className="absolute top-0 left-0 w-full h-full object-cover"
+      >
+        <source src="/background.mp4" type="video/mp4" />
+      </video>
+      <div className="relative z-10 flex flex-col min-h-screen">
+        <div className="flex-1" />
+        <footer className="p-4 flex justify-center">
+          <LoginButton />
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/components/LoginButton.tsx
+++ b/components/LoginButton.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { MiniKit } from "@worldcoin/minikit-js";
+import { Button } from "@worldcoin/mini-apps-ui-kit-react";
+import { useRouter } from "next/navigation";
+import { playBackgroundVideo } from "@/lib/playVideo";
+import { useState } from "react";
+
+export const LoginButton = () => {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  const handleLogin = async () => {
+    if (!MiniKit.isInstalled()) {
+      return;
+    }
+
+    setLoading(true);
+    playBackgroundVideo();
+
+    const res = await fetch(`/api/nonce`);
+    const { nonce } = await res.json();
+
+    const { finalPayload } = await MiniKit.commandsAsync.walletAuth({
+      nonce,
+      requestId: "0",
+      expirationTime: new Date(new Date().getTime() + 7 * 24 * 60 * 60 * 1000),
+      notBefore: new Date(new Date().getTime() - 24 * 60 * 60 * 1000),
+      statement: "Login to Ajna",
+    });
+
+    if (finalPayload.status !== "error") {
+      await fetch("/api/complete-siwe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ payload: finalPayload, nonce }),
+      });
+      router.push("/universe");
+    }
+
+    setLoading(false);
+  };
+
+  return (
+    <Button onClick={handleLogin} variant="primary" size="lg" disabled={loading}>
+      Login with Wallet
+    </Button>
+  );
+};


### PR DESCRIPTION
## Summary
- add LoginButton component to authenticate with wallet
- add /login page mirroring homepage with login button
- add /api/nonce and /api/complete-siwe endpoints for wallet auth

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_683b64b4e5fc8322a12d1c4b947765df