### PR TITLE
Implement SIWE login with NextAuth

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,9 +1,43 @@
 import NextAuth, { NextAuthOptions } from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
+import { verifySiweMessage, type MiniAppWalletAuthSuccessPayload } from "@worldcoin/minikit-js";
+import { cookies } from "next/headers";
 
 const authOptions: NextAuthOptions = {
   secret: process.env.NEXTAUTH_SECRET,
 
   providers: [
+    CredentialsProvider({
+      name: "Ethereum (SIWE)",
+      credentials: {
+        payload: { label: "Payload", type: "text" },
+        nonce: { label: "Nonce", type: "text" },
+      },
+      async authorize(credentials) {
+        try {
+          if (!credentials) return null;
+          const { payload, nonce } = credentials;
+          const parsed = JSON.parse(payload) as MiniAppWalletAuthSuccessPayload;
+
+          const cookieNonce = cookies().get("siwe_nonce")?.value ?? "";
+          if (nonce !== cookieNonce) return null;
+
+          const { isValid } = await verifySiweMessage(parsed, nonce);
+          if (!isValid) return null;
+
+          cookies().delete("siwe_nonce");
+
+          return {
+            id: parsed.address,
+            name: parsed.address,
+            address: parsed.address,
+          } as any;
+        } catch (e) {
+          console.error(e);
+          return null;
+        }
+      },
+    }),
     {
       id: "worldcoin",
       name: "Worldcoin",
@@ -25,9 +59,24 @@ const authOptions: NextAuthOptions = {
     },
   ],
   callbacks: {
+    async session({ session, token }) {
+      if (token.sub) {
+        session.user = { ...session.user, address: token.sub };
+      }
+      return session;
+    },
+    async jwt({ token, user }) {
+      if (user && (user as any).address) {
+        token.sub = (user as any).address;
+      }
+      return token;
+    },
     async signIn({ user }) {
       return true;
     },
+  },
+  session: {
+    strategy: "jwt",
   },
   debug: process.env.NODE_ENV === "development",
 };

--- a/app/api/nonce/route.ts
+++ b/app/api/nonce/route.ts
@@ -1,8 +1,13 @@
 import { cookies } from "next/headers";
-import { NextRequest, NextResponse } from "next/server";
-
-export function GET(req: NextRequest) {
-  const nonce = crypto.randomUUID().replace(/-/g, "");
-  cookies().set("siwe", nonce, { secure: true });
+import { NextResponse } from "next/server";
+import { randomBytes } from "crypto";
+export function GET() {
+  const nonce = randomBytes(16).toString("hex");
+  cookies().set("siwe_nonce", nonce, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: true,
+    maxAge: 300,
+  });
   return NextResponse.json({ nonce });
 }

--- a/components/LoginButton.tsx
+++ b/components/LoginButton.tsx
@@ -4,6 +4,7 @@ import { Button } from "@worldcoin/mini-apps-ui-kit-react";
 import { useRouter } from "next/navigation";
 import { playBackgroundVideo } from "@/lib/playVideo";
 import { useState } from "react";
+import { signIn } from "next-auth/react";
 
 export const LoginButton = () => {
   const router = useRouter();
@@ -29,11 +30,16 @@ export const LoginButton = () => {
     });
 
     if (finalPayload.status !== "error") {
-      await fetch("/api/complete-siwe", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ payload: finalPayload, nonce }),
+      const resSignIn = await signIn("credentials", {
+        redirect: false,
+        payload: JSON.stringify(finalPayload),
+        nonce,
       });
+      if (!resSignIn || resSignIn.error) {
+        console.error(resSignIn?.error);
+        setLoading(false);
+        return;
+      }
       router.push("/universe");
     }
 


### PR DESCRIPTION
## Summary
- enhance `/api/nonce` to set secure nonce cookie
- integrate Credentials provider in NextAuth to verify wallet auth
- use credential sign-in in `LoginButton`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_683b7084c13c8322ad96fbd609ae3b83