### PR TITLE
Add Blockscout link after mint

### DIFF
--- a/app/wait/page.tsx
+++ b/app/wait/page.tsx
@@ -1,11 +1,37 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { BackButton } from "@/components/BackButton";
+import { Button } from "@worldcoin/mini-apps-ui-kit-react";
 
 export default function WaitPage() {
+  const [txHash, setTxHash] = useState<string | null>(null);
+
+  useEffect(() => {
+    const storedHash = typeof window !== "undefined" ? localStorage.getItem("mintTxHash") : null;
+    if (storedHash) {
+      setTxHash(storedHash);
+    }
+  }, []);
+
   return (
-    <main className="flex min-h-screen flex-col p-4">
+    <main className="flex min-h-screen flex-col p-4 gap-6">
       <BackButton />
+      <div className="flex-1 flex flex-col items-center justify-center gap-4">
+        {txHash ? (
+          <Button asChild variant="primary" size="lg">
+            <a
+              href={`https://blockscout.com/tx/${txHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View Transaction on Blockscout
+            </a>
+          </Button>
+        ) : (
+          <p className="text-center">Minting NFT...</p>
+        )}
+      </div>
     </main>
   );
 }

--- a/components/MintNFT.tsx
+++ b/components/MintNFT.tsx
@@ -104,6 +104,9 @@ export const MintNFT = () => {
 
       if (txHash) {
         setSuccessTxHash(txHash)
+        if (typeof window !== 'undefined') {
+          localStorage.setItem('mintTxHash', txHash)
+        }
       } else if ((response.finalPayload as any)?.error_code) {
         throw new Error('Transaction failed')
       }
@@ -143,17 +146,18 @@ export const MintNFT = () => {
       </Button>
       {error && <p className="text-red-600">{error}</p>}
       {successTxHash && (
-        <p className="text-green-600 break-all">
-          Transaction sent! TxHash{' '}
-          <a
-            href={`https://worldchain-mainnet.explorer.alchemy.com/tx/${successTxHash}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            {successTxHash}
-          </a>
-        </p>
+        <div className="flex flex-col items-center gap-2">
+          <p className="text-green-600 break-all">Transaction sent!</p>
+          <Button asChild variant="primary" size="lg">
+            <a
+              href={`https://blockscout.com/tx/${successTxHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View on Blockscout
+            </a>
+          </Button>
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- store minted transaction hash in localStorage
- show link to Blockscout when minting succeeds
- display Blockscout transaction link on the wait page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683bac7b72a88322b290291060a0cfbd